### PR TITLE
ci: improve GitHub Actions configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,32 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
+    branches: [ main ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: build (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        # TODO: Remove once https://github.com/dart-lang/sdk/issues/55745
+        #       has been resolved
+        sdk: [stable, 3.3.0]
+        exclude:
+          - os: macos-latest
+            sdk: 3.3.0
+          - os: ubuntu-latest
+            sdk: 3.3.0
+          - os: windows-latest
+            sdk: stable
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: dart pub get
@@ -24,14 +42,11 @@ jobs:
         run: dart analyze
 
       - name: Run tests with coverage
-        run: dart test --coverage="coverage"
+        run: dart run coverage:test_with_coverage
 
-      - name: Convert coverage to ICOV
-        run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --report-on=lib
-
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.lcov
+          file: coverage/lcov.info
           name: Upload to codecov.io
           verbose: true


### PR DESCRIPTION
This PR improves the GitHub Actions configuration, letting the CI also run on Windows and macOS. It also simplifies the way the code coverage report is being generated.

Due to a bug in the Dart SDK, the Action uses Dart version 3.3 instead of the latest version (3.4) on Windows at the moment.