### PR TITLE
ci: add release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: dart


### PR DESCRIPTION
This PR adds a config for the [release-please GitHub Action](https://github.com/googleapis/release-please-action). I am not yet sure how well it will work, so adding it (in this repository) has to be considered an experiment, which I will adapt to other projects as well if it turns out to be a success.